### PR TITLE
Don't mutate the user-supplied options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,15 +15,9 @@ const importJsx = (moduleId, options) => {
 	const modulePath = resolveFrom(path.dirname(callerPath()), moduleId);
 	const source = fs.readFileSync(modulePath, 'utf8');
 
-	options = options || {};
-
-	if (!options.pragma) {
-		if (source.indexOf('React') >= 0) {
-			options.pragma = 'React.createElement';
-		} else {
-			options.pragma = 'h';
-		}
-	}
+	options = Object.assign({
+		pragma: source.includes('React') ? 'React.createElement' : 'h'
+	}, options);
 
 	const result = buble.transform(source, {
 		transforms: {


### PR DESCRIPTION
If the user uses the same options object for multiple calls it will have unexpected behavior.

I also simplified the code by using `String#includes()` and a ternary.