### PR TITLE
Ignore babel.config.js to avoid incompatible plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,8 @@ const importJsx = (moduleId, options) => {
 				plugins,
 				filename: modulePath,
 				sourceMaps: 'inline',
-				babelrc: false
+				babelrc: false,
+				configFile: false
 			});
 
 			module._compile = oldCompile;


### PR DESCRIPTION
This will fix issues where some babel plugins such as `@babel/plugin-transform-modules-commonjs` used in a local project `babel.config.js` will cause `caller-path` to skip files transformed by import-jsx.  I think this becomes a problem for recursive `import-jsx` - one JSX importing another such as what happens in treport.  Since `babelrc: false` is already provided I assume `configFile: false` was just missed when upgrading to babel 7.

Ref https://github.com/tapjs/node-tap/issues/624