### PR TITLE
Add a disk cache for transpiled files

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -51,19 +51,19 @@ const handleCache = (directory, params) => {
 		// No errors mean that the file was previously cached
 		// we just need to return it
 		return fs.readFileSync(file).toString();
-	} catch (error) {}
+	} catch (err) {}
 
 	const fallback = directory !== os.tmpdir();
 
 	// Make sure the directory exists.
 	try {
 		mkdirp.sync(directory);
-	} catch (error) {
+	} catch (err) {
 		if (fallback) {
 			return handleCache(os.tmpdir(), params);
 		}
 
-		throw error;
+		throw err;
 	}
 
 	// Otherwise just transform the file
@@ -72,13 +72,13 @@ const handleCache = (directory, params) => {
 
 	try {
 		fs.writeFileSync(file, result);
-	} catch (error) {
+	} catch (err) {
 		if (fallback) {
 			// Fallback to tmpdir if node_modules folder not writable
 			return handleCache(os.tmpdir(), params);
 		}
 
-		throw error;
+		throw err;
 	}
 
 	return result;

--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,128 @@
+/**
+ * Filesystem Cache
+ *
+ * Based on https://github.com/babel/babel-loader/blob/15df92fafd58ec53ba88efa22de7b2cee5e65fcc/src/cache.js
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+const mkdirp = require('mkdirp');
+const findCacheDir = require('find-cache-dir');
+const transform = require('./transform');
+
+let directory = null;
+
+/**
+ * Read the contents from the file.
+ *
+ * @params {String} filename
+ */
+const read = filename => {
+	const data = fs.readFileSync(filename);
+
+	return JSON.parse(data.toString());
+};
+
+/**
+ * Write contents into a file.
+ *
+ * @params {String} filename
+ * @params {String} result
+ */
+const write = (filename, result) => {
+	const content = JSON.stringify(result);
+
+	return fs.writeFileSync(filename, content);
+};
+
+/**
+ * Build the filename for the cached file
+ *
+ * @param  {String} source  Original contents of the file to be cached
+ * @param  {Object} options Options passed to importJsx
+ * @param  {String} version Version of import-jsx
+ *
+ * @return {String}
+ */
+const filename = (source, options, version) => {
+	const hash = crypto.createHash('md4');
+
+	const contents = JSON.stringify({source, options, version});
+
+	hash.update(contents);
+
+	return hash.digest('hex') + '.json';
+};
+
+/**
+ * Handle the cache
+ *
+ * @params {String} directory
+ * @params {Object} params
+ */
+const handleCache = (directory, params) => {
+	const {
+    modulePath,
+    options,
+		source,
+		version
+	} = params;
+
+	const file = path.join(directory, filename(source, options, version));
+
+	try {
+		// No errors mean that the file was previously cached
+		// we just need to return it
+		return read(file);
+	} catch (err) {}
+
+	const fallback = directory !== os.tmpdir();
+
+	// Make sure the directory exists.
+	try {
+		mkdirp.sync(directory);
+	} catch (err) {
+		if (fallback) {
+			return handleCache(os.tmpdir(), params);
+		}
+
+		throw err;
+	}
+
+	// Otherwise just transform the file
+	// return it to the user asap and write it in cache
+	const result = transform(source, options, modulePath);
+
+	try {
+		write(file, result);
+	} catch (err) {
+		if (fallback) {
+			// Fallback to tmpdir if node_modules folder not writable
+			return handleCache(os.tmpdir(), params);
+		}
+
+		throw err;
+	}
+
+	return result;
+};
+
+/**
+ * Retrieve file from cache, or create a new one for future reads
+ *
+ * @param  {Object}   params
+ * @param  {String}   params.modulePath
+ * @param  {String}   params.source     Original contents of the file to be cached
+ * @param  {Object}   params.options    Options passed to importJsx
+ * @param  {String}   params.version    Version of import-jsx
+ */
+
+module.exports = params => {
+	if (directory === null) {
+		directory =
+			findCacheDir({name: 'import-jsx'}) || os.tmpdir();
+	}
+
+	return handleCache(directory, params);
+};

--- a/cache.js
+++ b/cache.js
@@ -94,11 +94,9 @@ const handleCache = (directory, params) => {
  * @param  {Object}   params.options    Options passed to importJsx
  * @param  {String}   params.version    Version of import-jsx
  */
-
 module.exports = params => {
 	if (directory === null) {
-		directory =
-			findCacheDir({name: 'import-jsx'}) || os.tmpdir();
+		directory = findCacheDir({name: 'import-jsx'}) || os.tmpdir();
 	}
 
 	return handleCache(directory, params);

--- a/cache.js
+++ b/cache.js
@@ -14,29 +14,6 @@ const transform = require('./transform');
 let directory = null;
 
 /**
- * Read the contents from the file.
- *
- * @params {String} filename
- */
-const read = filename => {
-	const data = fs.readFileSync(filename);
-
-	return JSON.parse(data.toString());
-};
-
-/**
- * Write contents into a file.
- *
- * @params {String} filename
- * @params {String} result
- */
-const write = (filename, result) => {
-	const content = JSON.stringify(result);
-
-	return fs.writeFileSync(filename, content);
-};
-
-/**
  * Build the filename for the cached file
  *
  * @param  {String} source  Original contents of the file to be cached
@@ -74,7 +51,7 @@ const handleCache = (directory, params) => {
 	try {
 		// No errors mean that the file was previously cached
 		// we just need to return it
-		return read(file);
+		return fs.readFileSync(file).toString();
 	} catch (err) {}
 
 	const fallback = directory !== os.tmpdir();
@@ -95,7 +72,7 @@ const handleCache = (directory, params) => {
 	const result = transform(source, options, modulePath);
 
 	try {
-		write(file, result);
+		fs.writeFileSync(file, result);
 	} catch (err) {
 		if (fallback) {
 			// Fallback to tmpdir if node_modules folder not writable

--- a/cache.js
+++ b/cache.js
@@ -26,12 +26,6 @@ let directory;
 const filename = (source, options, version) => {
 	const hash = crypto.createHash('md4');
 	const contents = JSON.stringify({source, options, version});
- 	hash.update(contents);
- 	
- 	return hash.digest('hex') + '.js';
-
-	const contents = JSON.stringify({source, options, version});
-
 	hash.update(contents);
 
 	return hash.digest('hex') + '.js';
@@ -69,7 +63,7 @@ const handleCache = (directory, params) => {
 			return handleCache(os.tmpdir(), params);
 		}
 
-		throw err;
+		throw error;
 	}
 
 	// Otherwise just transform the file
@@ -84,7 +78,7 @@ const handleCache = (directory, params) => {
 			return handleCache(os.tmpdir(), params);
 		}
 
-		throw err;
+		throw error;
 	}
 
 	return result;

--- a/cache.js
+++ b/cache.js
@@ -1,9 +1,5 @@
 'use strict';
-/**
- * Filesystem Cache
- *
- * Based on https://github.com/babel/babel-loader/blob/15df92fafd58ec53ba88efa22de7b2cee5e65fcc/src/cache.js
- */
+// Based on https://github.com/babel/babel-loader/blob/15df92fafd58ec53ba88efa22de7b2cee5e65fcc/src/cache.js
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -55,19 +51,19 @@ const handleCache = (directory, params) => {
 		// No errors mean that the file was previously cached
 		// we just need to return it
 		return fs.readFileSync(file).toString();
-	} catch (err) {}
+	} catch (error) {}
 
 	const fallback = directory !== os.tmpdir();
 
 	// Make sure the directory exists.
 	try {
 		mkdirp.sync(directory);
-	} catch (err) {
+	} catch (error) {
 		if (fallback) {
 			return handleCache(os.tmpdir(), params);
 		}
 
-		throw err;
+		throw error;
 	}
 
 	// Otherwise just transform the file
@@ -76,13 +72,13 @@ const handleCache = (directory, params) => {
 
 	try {
 		fs.writeFileSync(file, result);
-	} catch (err) {
+	} catch (error) {
 		if (fallback) {
 			// Fallback to tmpdir if node_modules folder not writable
 			return handleCache(os.tmpdir(), params);
 		}
 
-		throw err;
+		throw error;
 	}
 
 	return result;

--- a/cache.js
+++ b/cache.js
@@ -45,6 +45,10 @@ const handleCache = (directory, params) => {
 		version
 	} = params;
 
+	if (!options.cache) {
+		return transform(source, options, modulePath);
+	}
+
 	const file = path.join(directory, filename(source, options, version));
 
 	try {

--- a/cache.js
+++ b/cache.js
@@ -52,7 +52,7 @@ const filename = (source, options, version) => {
 
 	hash.update(contents);
 
-	return hash.digest('hex') + '.json';
+	return hash.digest('hex') + '.js';
 };
 
 /**
@@ -63,8 +63,8 @@ const filename = (source, options, version) => {
  */
 const handleCache = (directory, params) => {
 	const {
-    modulePath,
-    options,
+		modulePath,
+		options,
 		source,
 		version
 	} = params;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/plugin-transform-destructuring": "^7.5.0",
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "caller-path": "^2.0.0",
-    "find-cache-dir": "^2.1.0",
+    "find-cache-dir": "^3.2.0",
     "mkdirp": "^0.5.1",
     "resolve-from": "^3.0.0",
     "rimraf": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test": "xo && nyc --check-coverage --branches=100 --lines=100 --functions=100 --statements=100 --exclude=cache.js --exclude=test ava"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "cache.js",
+    "transform.js"
   ],
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "caller-path": "^2.0.0",
     "find-cache-dir": "^3.1.0",
     "mkdirp": "^0.5.1",
-    "resolve-from": "^3.0.0"
+    "resolve-from": "^3.0.0",
+    "rimraf": "^3.0.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@babel/plugin-transform-destructuring": "^7.5.0",
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "caller-path": "^2.0.0",
+    "find-cache-dir": "^3.1.0",
+    "mkdirp": "^0.5.1",
     "resolve-from": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@babel/plugin-transform-destructuring": "^7.5.0",
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "caller-path": "^2.0.0",
-    "find-cache-dir": "^3.1.0",
+    "find-cache-dir": "^2.1.0",
     "mkdirp": "^0.5.1",
     "resolve-from": "^3.0.0",
     "rimraf": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">= 4"
   },
   "scripts": {
-    "test": "xo && nyc --check-coverage --branches=100 --lines=100 --functions=100 --statements=100 ava"
+    "test": "xo && nyc --check-coverage --branches=100 --lines=100 --functions=100 --statements=100 --exclude=cache.js --exclude=test ava"
   },
   "files": [
     "index.js"

--- a/test/fixtures/for-cache.js
+++ b/test/fixtures/for-cache.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = "For testing the disk cache!";

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const os = require('os');
 const test = require('ava');
 const findCacheDir = require('find-cache-dir');
 const rimraf = require('rimraf');
 const importJsx = require('..');
 
 // Clear cache
-const cacheDirectory = findCacheDir({name: 'import-jsx'}) || os.tmpdir();
+const cacheDirectory = findCacheDir({name: 'import-jsx'});
 rimraf.sync(cacheDirectory);
 
 const fixturePath = name => `${__dirname}/fixtures/${name}`;

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,14 @@
 'use strict';
 
+const os = require('os');
 const test = require('ava');
+const findCacheDir = require('find-cache-dir');
+const rimraf = require('rimraf');
 const importJsx = require('..');
+
+// Clear cache
+const cacheDirectory = findCacheDir({name: 'import-jsx'}) || os.tmpdir();
+rimraf.sync(cacheDirectory);
 
 const fixturePath = name => `${__dirname}/fixtures/${name}`;
 const isCached = path => Boolean(Object.keys(require.cache).includes(path + '.js'));

--- a/test/test.js
+++ b/test/test.js
@@ -81,6 +81,12 @@ test('works when destructuring isnt available natively', t => {
 	t.is(result.y, 'b');
 });
 
+test('parse React fragments', t => {
+	t.notThrows(() => {
+		importJsx(fixturePath('react-fragment'));
+	});
+});
+
 const diskCacheFile = `${diskCacheDirectory}/f478c8d5f1d242d6e659f8c40f33374c.js`;
 
 test('creates appropriate cache file on disk', t => {

--- a/transform.js
+++ b/transform.js
@@ -11,6 +11,7 @@ const transform = (source, options, modulePath) => {
 		restSpreadTransform = require('@babel/plugin-proposal-object-rest-spread');
 		jsxTransform = require('@babel/plugin-transform-react-jsx');
 	}
+
 	if (source.includes('React')) {
 		options.pragma = 'React.createElement';
 		options.pragmaFrag = 'React.Fragment';

--- a/transform.js
+++ b/transform.js
@@ -1,0 +1,35 @@
+// Only load these if compiled source is not already cached
+let babel;
+let destructuringTransform;
+let restSpreadTransform;
+let jsxTransform;
+
+const transform = (source, options, modulePath) => {
+	if (!babel) {
+		babel = require('@babel/core');
+		destructuringTransform = require('@babel/plugin-transform-destructuring');
+		restSpreadTransform = require('@babel/plugin-proposal-object-rest-spread');
+		jsxTransform = require('@babel/plugin-transform-react-jsx');
+	}
+	if (source.includes('React')) {
+		options.pragma = 'React.createElement';
+		options.pragmaFrag = 'React.Fragment';
+	}
+
+	const plugins = [
+		[restSpreadTransform, {useBuiltIns: true}],
+		options.supportsDestructuring ? null : destructuringTransform,
+		[jsxTransform, {pragma: options.pragma, pragmaFrag: options.pragmaFrag, useBuiltIns: true}]
+	].filter(Boolean);
+
+	const result = babel.transformSync(source, {
+		plugins,
+		filename: modulePath,
+		sourceMaps: 'inline',
+		babelrc: false
+	});
+
+	return result.code;
+};
+
+module.exports = transform;


### PR DESCRIPTION
I tried to address all the ideas in #5 by caching transpiled JS files in node_modules/.cache/import-jsx. babel-loader [has a cache that does basically the same thing](https://github.com/babel/babel-loader/blob/f63f4d87845d5baaeb67107646fd5ae0e5aae2cd/src/cache.js), I tried to make the minimal changes needed to work here (like getting rid of all the async stuff).

Some rough benchmarks...

| File Size | First run | Cached |
| - | - | - |
| 0.1kb | 0.4s | 0.07s |
| 30kb | 1.4s | 0.09s |
| 300kb | 24s | 0.14s |

That's a pretty nice gain, even for tiny files!

I know this PR hurts your test coverage... it's just for all the edge cases in cache.js, like if you don't have write permission to node_modules. Not sure if it's worth doing anything about that.

(Also thanks for Ink, I tried it for the first time yesterday and it kinda blew my mind how easy it was to make some pretty CLI output! But the half-second delay added when using import-jsx was mildly annoying, and I didn't want to add a build step, so here I am..)