### PR TITLE
Use loader hooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [10, 12, 14, 16]
+        node_version: [16, 18]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
-      - name: Test
-        run: |
-          npm install
-          npm test
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "email": "vdemedes@gmail.com",
     "url": "github.com/vadimdemedes"
   },
+  "type": "module",
+  "exports": "./index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=14.16"
   },
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && ava --serial"
   },
   "files": [
     "index.js",
@@ -28,20 +30,22 @@
     "import"
   ],
   "dependencies": {
-    "@babel/core": "^7.5.5",
-    "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-    "@babel/plugin-transform-destructuring": "^7.5.0",
-    "@babel/plugin-transform-react-jsx": "^7.3.0",
-    "caller-path": "^3.0.1",
-    "find-cache-dir": "^3.2.0",
-    "make-dir": "^3.0.2",
-    "resolve-from": "^3.0.0",
-    "rimraf": "^3.0.0"
+    "@babel/core": "^7.21.0",
+    "@babel/preset-react": "^7.18.6",
+    "find-cache-dir": "^4.0.0",
+    "make-dir": "^3.1.0"
   },
   "devDependencies": {
-    "ava": "^0.19.1",
+    "@babel/eslint-parser": "^7.19.1",
+    "ava": "^5.2.0",
+    "del": "^7.0.0",
+    "execa": "^7.0.0",
+    "preact": "^10.13.0",
+    "preact-render-to-string": "^5.2.6",
     "prettier": "^2.0.2",
-    "xo": "^0.28.1"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "xo": "^0.53.1"
   },
   "prettier": {
     "tabs": true,
@@ -51,11 +55,20 @@
     "arrowParens": "avoid"
   },
   "xo": {
+    "prettier": true,
+    "parser": "@babel/eslint-parser",
+    "parserOptions": {
+      "requireConfigFile": false,
+      "babelOptions": {
+        "parserOpts": {
+          "plugins": [
+            "importAssertions"
+          ]
+        }
+      }
+    },
     "ignore": [
       "test/fixtures"
-    ],
-    "rules": {
-      "node/no-deprecated-api": "off"
-    }
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -10,18 +10,18 @@ npm install import-jsx
 
 ## Usage
 
-**react-example.js**
-
-```jsx
-const HelloWorld = () => <h1>Hello world</h1>;
-```
+> **Note**:
+> `import-jsx` only works with ES modules.
 
 ```sh
 node --loader=import-jsx react-example.js
 ```
 
-> **Note**:
-> `import-jsx` only works with ES modules.
+**react-example.js**
+
+```jsx
+const HelloWorld = () => <h1>Hello world</h1>;
+```
 
 ## Examples
 

--- a/test/fixtures/automatic-preact.js
+++ b/test/fixtures/automatic-preact.js
@@ -1,0 +1,4 @@
+/** @jsxImportSource preact */
+import render from 'preact-render-to-string';
+
+console.log(render(<h1>Hello world</h1>));

--- a/test/fixtures/automatic-react.js
+++ b/test/fixtures/automatic-react.js
@@ -1,0 +1,3 @@
+import ReactDOMServer from 'react-dom/server';
+
+console.log(ReactDOMServer.renderToStaticMarkup(<h1>Hello world</h1>));

--- a/test/fixtures/classic-preact.js
+++ b/test/fixtures/classic-preact.js
@@ -1,0 +1,6 @@
+/** @jsxRuntime classic */
+/** @jsx h */
+import {h} from 'preact';
+import render from 'preact-render-to-string';
+
+console.log(render(<h1>Hello world</h1>));

--- a/test/fixtures/classic-react.js
+++ b/test/fixtures/classic-react.js
@@ -1,0 +1,5 @@
+/** @jsxRuntime classic */
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+
+console.log(ReactDOMServer.renderToStaticMarkup(<h1>Hello world</h1>));

--- a/test/fixtures/custom.js
+++ b/test/fixtures/custom.js
@@ -1,4 +1,0 @@
-'use strict';
-const x = () => {};
-
-<div />;

--- a/test/fixtures/disk-cache.js
+++ b/test/fixtures/disk-cache.js
@@ -1,0 +1,1 @@
+console.log('This is not from disk');

--- a/test/fixtures/for-cache.js
+++ b/test/fixtures/for-cache.js
@@ -1,2 +1,0 @@
-'use strict';
-module.exports = 'For testing the disk cache!';

--- a/test/fixtures/jsx-ext.jsx
+++ b/test/fixtures/jsx-ext.jsx
@@ -1,6 +1,0 @@
-'use strict';
-const React = {createElement: () => {}};
-
-<div />;
-
-module.exports = {exty: true};

--- a/test/fixtures/other.js
+++ b/test/fixtures/other.js
@@ -1,4 +1,0 @@
-'use strict';
-const h = () => {};
-
-<div />;

--- a/test/fixtures/react-fragment.js
+++ b/test/fixtures/react-fragment.js
@@ -1,6 +1,0 @@
-'use strict';
-const React = {createElement: () => {}};
-
-<>
-	<div />
-</>;

--- a/test/fixtures/react.js
+++ b/test/fixtures/react.js
@@ -1,4 +1,0 @@
-'use strict';
-const React = {createElement: () => {}};
-
-<div />;

--- a/transform.js
+++ b/transform.js
@@ -1,33 +1,28 @@
-'use strict';
 // Only load these if compiled source is not already cached
 let babel;
-let jsxTransform;
+let reactPreset;
 
-const transform = (source, options, modulePath) => {
+const transform = async (source, filename) => {
 	if (!babel) {
-		babel = require('@babel/core');
-		jsxTransform = require('@babel/plugin-transform-react-jsx');
+		babel = await import('@babel/core');
+		reactPreset = await import('@babel/preset-react');
 	}
 
-	if (source.includes('React')) {
-		options.pragma = 'React.createElement';
-		options.pragmaFrag = 'React.Fragment';
-	}
-
-	const plugins = [
+	const presets = [
 		[
-			jsxTransform,
+			reactPreset.default,
 			{
-				pragma: options.pragma,
-				pragmaFrag: options.pragmaFrag,
-				useBuiltIns: true
+				runtime: 'automatic',
+				pure: false,
+				useBuiltIns: true,
+				useSpread: true
 			}
 		]
-	].filter(Boolean);
+	];
 
-	const result = babel.transformSync(source, {
-		plugins,
-		filename: modulePath,
+	const result = await babel.transformAsync(source, {
+		presets,
+		filename,
 		sourceMaps: 'inline',
 		babelrc: false,
 		configFile: false
@@ -36,4 +31,4 @@ const transform = (source, options, modulePath) => {
 	return result.code;
 };
 
-module.exports = transform;
+export default transform;


### PR DESCRIPTION
Fixes #15.

This PR converts this package to ESM. Because of that, it's no longer possible to export an API like `importJsx('file.js')`, because ESM doesn't support that.

Instead, `import-jsx` is now a [loader hook](https://nodejs.org/dist/latest-v18.x/docs/api/esm.html#loaders):

```console
node --loader=import-jsx file-with-jsx.js
```